### PR TITLE
Add Menu Classes to Menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,8 @@ function generate()
     $this->menu->add('Edit Myself', 'route:users.edit|id:5');   // Method 5
     $this->menu->add('Logout')->route('auth.logout');           // Method 6
     $this->menu->add('Some Other Link', ['url' => '/link']);    // Method 7
-    $this->menu->add('Sub Menu', 'menu:sub_menu_name);          // Method 8
+    $this->menu->add('Sub Menu', 'menu:menu_name);          // Method 8
+    $this->menu->add('Sub Menu', 'sub-menu:sub_menu_name);          // Method 9
     
 }
 ```
@@ -132,7 +133,8 @@ function generate()
 | 5             | The `$this->menu` instance | The route is associated with arguments, useful to create a quick route with parameters.                                                                          |
 | 6             | A new `MenuItem`           | The route is assigned using the fluent interface, which makes the code look cleaner. You can also add an array of route parameters as the second argument.       |
 | 7             | The `$this->menu` instance | You can pass an array as the second argument to immediately issue all the variables to the menu item, when you don't want to use the fluent interface.           |
-| 8             | The `$this->menu` instance | You can pass the name of another menu and the class will pull in that menu as a sub menu.           |
+| 8             | The `$this->menu` instance | You can pass the name of another menu and the class will merge that menu with this menu.           |
+| 9             | The `$this->menu` instance | You can pass the name of another menu and the class will pull in that menu as a sub menu.           |
 
 
 

--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ function generate()
     $this->menu->add('Edit Myself', 'route:users.edit|id:5');   // Method 5
     $this->menu->add('Logout')->route('auth.logout');           // Method 6
     $this->menu->add('Some Other Link', ['url' => '/link']);    // Method 7
+    $this->menu->add('Sub Menu', 'menu:sub_menu_name);          // Method 8
     
 }
 ```
@@ -131,6 +132,7 @@ function generate()
 | 5             | The `$this->menu` instance | The route is associated with arguments, useful to create a quick route with parameters.                                                                          |
 | 6             | A new `MenuItem`           | The route is assigned using the fluent interface, which makes the code look cleaner. You can also add an array of route parameters as the second argument.       |
 | 7             | The `$this->menu` instance | You can pass an array as the second argument to immediately issue all the variables to the menu item, when you don't want to use the fluent interface.           |
+| 8             | The `$this->menu` instance | You can pass the name of another menu and the class will pull in that menu as a sub menu.           |
 
 
 

--- a/src/CreatesMenuItems.php
+++ b/src/CreatesMenuItems.php
@@ -93,6 +93,19 @@ trait CreatesMenuItems
 
             return $this;
         }
+        
+        //Is it another Menu
+        if(starts_with($config, 'menu:')) {
+			$slug = $item['__slug__'] = snake_case($title);
+
+			foreach(app('menu')->get(str_replace_first('menu:', '', $config)) as $sub_item) {
+				$item->add($sub_item->title, $sub_item->_items);
+			}
+
+			$this->_items[$slug] = &$item;
+
+			return $this;
+		}
 
         // Else it's a plain url
         $this->_items[snake_case($title)] = &$item;

--- a/src/CreatesMenuItems.php
+++ b/src/CreatesMenuItems.php
@@ -94,15 +94,24 @@ trait CreatesMenuItems
             return $this;
         }
         
-        //Is it another Menu
-        if(starts_with($config, 'menu:')) {
+
+		// Is it another Menu?
+		if(starts_with($config, 'menu:') || starts_with($config, 'sub-menu:')) {
 			$slug = $item['__slug__'] = snake_case($title);
 
-			foreach(app('menu')->get(str_replace_first('menu:', '', $config)) as $sub_item) {
-				$item->add($sub_item->title, $sub_item->_items);
+			if(starts_with($config, 'menu:')) {
+				$items =& $this->_items;
+				$menu = app('menu')->get(str_replace_first('menu:', '', $config));
+			} else {// if(starts_with($config, 'sub-menu:')) {
+				$items =& $item->_items;
+				$menu = app('menu')->get(str_replace_first('sub-menu:', '', $config));
 			}
 
-			$this->_items[$slug] = &$item;
+			$items = array_merge($items, $menu->_items);
+
+			if(starts_with($config, 'sub-menu:')) {
+				$this->_items[$slug] = &$item;
+			}
 
 			return $this;
 		}


### PR DESCRIPTION
Allow user to add another menu to a menu, either as a sub-menu or merged into the current menu. This will be good for when there is various levels of permissions.